### PR TITLE
add proof for 5.4.24.c, formatting and minor fixes

### DIFF
--- a/src/Epp.tex
+++ b/src/Epp.tex
@@ -21301,14 +21301,12 @@ starting from \#1), we will have removed the people numbered
 $\#2, \#4, \ldots,\#(2m)$ leaving person \#$(2m+1)$ next in line.
 
 We also know that:
-\[
-\begin{align}
-    2^n + m &< 2^{n+1} \\
+\begin{align*}
+    2^n+m &< 2^{n+1} \\
     m &< 2^n \\
     m+1 &\le 2^n \\
     2m+1 &\le 2^n+m
-\end{align}
-\] 
+\end{align*}
 
 In other words, since $2m+1 \in [1,r]$, the elimination never loops 
 through the circle more than once; it terminates within the first 


### PR DESCRIPTION
- Added proof for 5.4.24.c
- Moved inline content after \begin{...} and before \end{...} to the next/previous line for consistency
- Replaced empty $ $ with correct variable (e.g. $u$); fixed malformed $mod$ usage; fixed wrong references