### PR TITLE
fix error in exercise 4.7.14

### DIFF
--- a/src/Epp.tex
+++ b/src/Epp.tex
@@ -14341,9 +14341,9 @@ So $\te$ an integer $a$ such that $a \mod 6 = 3$ and $a \mod 3 = 2$.
 
 By definition of mod used with $a \mod 6 = 3$, there exists an integer $r$ such that $a = 6r + 3$.
 
-By definition of mod used with $a \mod 6 = 2$, there exists an integer $s$ such that $a = 6s + 2$.
+By definition of mod used with $a \mod 3 = 2$, there exists an integer $s$ such that $a = 3s + 2$.
 
-So $6r + 3 = 6s + 2$. Therefore $1 = 6s - 6r = 6(r-s)$. Therefore $r-s = \frac{1}{6}$. But $r-s$ is an integer (being a difference of integers) while $\frac{1}{6}$ is not an integer, contradiction!
+So $6r + 3 = 3s + 2$. Therefore $1 = 3s - 6r = 3(s - 2r)$. Therefore $s-2r = \frac{1}{3}$. But $s-2r$ is an integer (being a difference of integers) while $\frac{1}{3}$ is not an integer, contradiction!
 
 {\it [Therefore our supposition was false, and $T$ is true.]}
 \end{proof}


### PR DESCRIPTION
There is a small mistake in exercise 4.7.14
<img width="1169" height="375" alt="image" src="https://github.com/user-attachments/assets/81dd36c6-4ffe-42cd-a0c3-6794f9418c51" />
