### PR TITLE
fix: 2.1.8 (e)

### DIFF
--- a/src/Epp.tex
+++ b/src/Epp.tex
@@ -2148,7 +2148,7 @@ $({\sim w} \wedge {\sim s}) \wedge h$.
 John is wealthy, but he is not both healthy and wise.
 
 \begin{proof}
-$w \wedge {\sim (h \wedge s)}$.
+$w \wedge {((h \vee s) \wedge {\sim (h \wedge s)})}$.
 \end{proof}
 
 \subsubsection{Exercise 9}


### PR DESCRIPTION
Question goes as follows:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4dbfe3b4-e699-47bb-9d7b-28a0af637d9e" />

Previous solution: 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1b710522-ea79-4568-9cf1-e7243c864fc4" />

New solution: 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8fb6a5bd-1bdc-4669-9551-578c4f736a42" />

Why the change?  
In my opinion, it is "exclusive or" there.