### PR TITLE
fix: 2.3.10

### DIFF
--- a/src/Epp.tex
+++ b/src/Epp.tex
@@ -4301,7 +4301,7 @@ $p \vee q \to r$
 $\therefore {\sim r} \to {\sim p} \wedge {\sim q}$
 
 \begin{proof}
-No need for a truth table. This argument is valid; it's just modus tollens!
+No need for a truth table. This argument is valid; it's just contrapositive!
 \end{proof}
 
 \subsubsection{Exercise 11}


### PR DESCRIPTION
The given statement form is valid because conclusion is contrapositive of the only conditional premises not because the given form is modus tollens.