### PR TITLE
fix: 3.2.8

### DIFF
--- a/src/Epp.tex
+++ b/src/Epp.tex
@@ -7910,9 +7910,9 @@ This number is related to some even number.
 Consider the statement “There are no simple solutions to life’s problems.” Write an informal negation for the statement, and then write the statement formally using quantifiers and variables.
 
 \begin{proof}
-Informal: “There is a simple solution to life’s problems.”
+Informal: “Some life problems have simple solutions.”
 
-Formal: $\te x$ such that $x$ is a simple solution to life's problems.
+Formal: $\te x$ life problem $x$ such that $x$ has a simple solution.
 \end{proof}
 
 {\bf \color{cyan}Write a negation for each statement in 9 and 10.}


### PR DESCRIPTION
Existing solution is not logically correct as it doesn't take the quantifier into account correctly.

### Existing solution
<img width="620" alt="file-88fd9425d7ec25c765298f5334e9f51f" src="https://github.com/user-attachments/assets/992548a3-c76b-44c2-8ff0-ec543ee307c9" />

### Problem with it
The given statement is equivalent to: $\forall \text{ life problems } x, x \text{ has no simple solution}$.  
For which the negation should be: $\exists \text{ life problem } x \text{ such that } x \text{ has a simple solution.}$
But the existing solution says: $\exists x \text{ such that } x \text{ is a simple solution to life's problems.}$ which has a different order or scope than the actual negation.


### Updated solution
<img width="620" alt="file-945ed1f1a5156f5e2fbf11c2d523ee81" src="https://github.com/user-attachments/assets/2c541946-f1fc-440e-8c5d-66c06b93fbe1" />
